### PR TITLE
Properly parse property subnodes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -188,8 +188,12 @@ dav.Client.prototype = {
 
                 var propNode = propIterator.iterateNext();
                 while(propNode) {
+                    var content = propNode.textContent;
+                    if (!content && propNode.hasChildNodes()) {
+                        content = propNode.childNodes;
+                    }
 
-                    propStat.properties['{' + propNode.namespaceURI + '}' + propNode.localName] = propNode.textContent;
+                    propStat.properties['{' + propNode.namespaceURI + '}' + propNode.localName] = content;
                     propNode = propIterator.iterateNext();
 
                 }


### PR DESCRIPTION
If the property contains XML, return the node instead of empty text.

This is especially important when parsing "d:resourcetype"
