### PR TITLE
Fix parsing with multiple properties

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -198,7 +198,7 @@ dav.Client.prototype = {
                 var propNode = propIterator.iterateNext();
                 while(propNode) {
                     var content = propNode.textContent;
-                    if (!content && propNode.hasChildNodes()) {
+                    if (propNode.childNodes && propNode.childNodes.length > 0 && propNode.childNodes[0].nodeType === 1) {
                         content = propNode.childNodes;
                     }
 


### PR DESCRIPTION
Detect if child node is really an XML node (not text), if yes then
return the children. Else keep the text content instead.

So far, `resourcetype` got parsed properly but more complex structures like:

``` xml
<oc:tags>
    <oc:tag>tag1</oc:tag>
    <oc:tag>tag2</oc:tag>
</oc:tags>
```

were not parsed properly.

This PR makes it work for both formats.
