### PR TITLE
Auto-parse multistatus if status code is 207

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,17 +1,17 @@
 if (typeof dav == 'undefined') { dav = {}; };
 
 dav._XML_CHAR_MAP = {
-	'<': '&lt;',
-	'>': '&gt;',
-	'&': '&amp;',
-	'"': '&quot;',
-	"'": '&apos;'
+    '<': '&lt;',
+    '>': '&gt;',
+    '&': '&amp;',
+    '"': '&quot;',
+    "'": '&apos;'
 };
 
 dav._escapeXml = function(s) {
-	return s.replace(/[<>&"']/g, function (ch) {
-		return dav._XML_CHAR_MAP[ch];
-	});
+    return s.replace(/[<>&"']/g, function (ch) {
+        return dav._XML_CHAR_MAP[ch];
+    });
 };
 
 dav.Client = function(options) {
@@ -79,17 +79,16 @@ dav.Client.prototype = {
         return this.request('PROPFIND', url, headers, body).then(
             function(result) {
 
-                var resultBody = this.parseMultiStatus(result.body);
                 if (depth===0) {
                     return {
                         status: result.status,
-                        body: resultBody[0],
+                        body: result.body[0],
                         xhr: result.xhr
                     };
                 } else {
                     return {
                         status: result.status,
-                        body: resultBody,
+                        body: result.body,
                         xhr: result.xhr
                     };
                 }
@@ -161,6 +160,7 @@ dav.Client.prototype = {
      */
     request : function(method, url, headers, body) {
 
+        var self = this;
         var xhr = this.xhrProvider();
 
         if (this.userName) {
@@ -182,8 +182,13 @@ dav.Client.prototype = {
                     return;
                 }
 
+                var resultBody = xhr.response;
+                if (xhr.status === 207) {
+                    resultBody = self.parseMultiStatus(xhr.response);
+                }
+
                 fulfill({
-                    body: xhr.response,
+                    body: resultBody,
                     status: xhr.status,
                     xhr: xhr
                 });


### PR DESCRIPTION
Regardless of the method, if the HTTP status code of the response is 207, automatically parse it.

I tested this with OC using the REPORT method, and also realized that PROPPATCH can also return multistatus in some case, as well as other methods in certain circumstances. (DELETE a collection)

@evert I hope it's not too dangerous.
