### PR TITLE
Edge MKCOL work around

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -172,7 +172,13 @@ dav.Client.prototype = {
         for(ii in headers) {
             xhr.setRequestHeader(ii, headers[ii]);
         }
-        xhr.send(body);
+
+        // Work around for edge
+        if (body === undefined) {
+            xhr.send();
+        } else {
+            xhr.send(body);
+        }
 
         return new Promise(function(fulfill, reject) {
 


### PR DESCRIPTION
When doing xhr.send(body) where body is undfined. Edge will still create a body, and content-type and content-length headers.

See: https://github.com/owncloud/core/issues/21710

CC: @evert @PVince81 
