### PR TITLE
Add mkcol method for extended mkcol

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,3 +1,4 @@
+/* global dav */
 if (typeof dav == 'undefined') { dav = {}; };
 
 dav._XML_CHAR_MAP = {
@@ -100,10 +101,42 @@ dav.Client.prototype = {
     },
 
     /**
+     * Renders a "d:set" block for the given properties.
+     *
+     * @param {Object.<String,String>} properties
+     * @return {String} XML "<d:set>" block
+     */
+    _renderPropSet: function(properties) {
+        var body = '  <d:set>\n' +
+            '   <d:prop>\n';
+
+        for(var ii in properties) {
+            var property = this.parseClarkNotation(ii);
+            var propName;
+            var propValue = properties[ii];
+            if (this.xmlNamespaces[property.namespace]) {
+                propName = this.xmlNamespaces[property.namespace] + ':' + property.name;
+            } else {
+                propName = 'x:' + property.name + ' xmlns:x="' + property.namespace + '"';
+            }
+
+            // FIXME: hard-coded for now until we allow properties to
+            // specify whether to be escaped or not
+            if (propName !== 'd:resourcetype') {
+                propValue = dav._escapeXml(propValue);
+            }
+            body += '      <' + propName + '>' + propValue + '</' + propName + '>\n';
+        }
+        body +='    </d:prop>\n';
+        body +='  </d:set>\n';
+        return body;
+    },
+
+    /**
      * Generates a propPatch request.
      *
      * @param {string} url Url to do the proppatch request on
-     * @param {Array} properties List of properties to store.
+     * @param {Object.<String,String>} properties List of properties to store.
      * @param {Object} [headers] headers
      * @return {Promise}
      */
@@ -119,27 +152,48 @@ dav.Client.prototype = {
         for (namespace in this.xmlNamespaces) {
             body += ' xmlns:' + this.xmlNamespaces[namespace] + '="' + namespace + '"';
         }
-        body += '>\n' +
-            '  <d:set>\n' +
-            '   <d:prop>\n';
-
-        for(var ii in properties) {
-
-            var property = this.parseClarkNotation(ii);
-            var propName;
-            var propValue = properties[ii];
-            if (this.xmlNamespaces[property.namespace]) {
-                propName = this.xmlNamespaces[property.namespace] + ':' + property.name;
-            } else {
-                propName = 'x:' + property.name + ' xmlns:x="' + property.namespace + '"';
-            }
-            body += '      <' + propName + '>' + dav._escapeXml(propValue) + '</' + propName + '>\n';
-        }
-        body+='    </d:prop>\n';
-        body+='  </d:set>\n';
-        body+='</d:propertyupdate>';
+        body += '>\n' + this._renderPropSet(properties);
+        body += '</d:propertyupdate>';
 
         return this.request('PROPPATCH', url, headers, body).then(
+            function(result) {
+                return {
+                    status: result.status,
+                    body: result.body,
+                    xhr: result.xhr
+                };
+            }.bind(this)
+        );
+
+    },
+
+    /**
+     * Generates a MKCOL request.
+     * If attributes are given, it will use an extended MKCOL request.
+     *
+     * @param {string} url Url to do the proppatch request on
+     * @param {Object.<String,String>} [properties] list of properties to store.
+     * @param {Object} [headers] headers
+     * @return {Promise}
+     */
+    mkcol : function(url, properties, headers) {
+        var body = '';
+        headers = headers || {};
+        headers['Content-Type'] = 'application/xml; charset=utf-8';
+
+        if (properties) {
+            body =
+                '<?xml version="1.0"?>\n' +
+                '<d:mkcol';
+            var namespace;
+            for (namespace in this.xmlNamespaces) {
+                body += ' xmlns:' + this.xmlNamespaces[namespace] + '="' + namespace + '"';
+            }
+            body += '>\n' + this._renderPropSet(properties);
+            body +='</d:mkcol>';
+        }
+
+        return this.request('MKCOL', url, headers, body).then(
             function(result) {
                 return {
                     status: result.status,


### PR DESCRIPTION
The mkcol() method does an extended mkcol by passing them in a "<d:set>"
block in the body. If "null" is passed instead of properties, an empty
body (regular mkcol) will be sent instead of an extended mkcol.

@evert please review