### PR TITLE
DAV client: Check if array itself has property in for loop

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -70,6 +70,9 @@ dav.Client.prototype = {
             '  <d:prop>\n';
 
         for(var ii in properties) {
+            if (!properties.hasOwnProperty(ii)) {
+                continue;
+            }
 
             var property = this.parseClarkNotation(properties[ii]);
             if (this.xmlNamespaces[property.namespace]) {
@@ -115,6 +118,10 @@ dav.Client.prototype = {
             '   <d:prop>\n';
 
         for(var ii in properties) {
+            if (!properties.hasOwnProperty(ii)) {
+                continue;
+            }
+
             var property = this.parseClarkNotation(ii);
             var propName;
             var propValue = properties[ii];


### PR DESCRIPTION
This prevents looping through properties of the array's prototype